### PR TITLE
Rename folder that needs to be match exactly with your structure

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./Components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {


### PR DESCRIPTION
Check ```tailwind.config.js``` file 

```js
content: [
    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
    "./Components/**/*.{js,ts,jsx,tsx,mdx}",
    "./app/*.{js,ts,jsx,tsx,mdx}",
  ],
```

The folder name is case sensitive. You wrote ```components``` instead of actual directory name is ```Components```

Check here - https://yimbs-corporation-vert.vercel.app

#### Resolved.